### PR TITLE
Add Google Analytics with consent verification

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import type { Metadata, Viewport } from "next"
 import { Suspense } from "react"
 import { Analytics } from "@vercel/analytics/react"
 import { LocalBusinessSchema, WebsiteSchema, RenovationCalculatorSchema, ServiceSchema, FAQSchema, ReviewSchema, OfferCatalogSchema } from "./components/structured-data"
+import GoogleAnalytics from "./components/google-analytics"
 
 const outfit = Outfit({
   subsets: ["latin"],
@@ -155,6 +156,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <OfferCatalogSchema />
       </head>
       <body className="min-h-screen bg-background antialiased font-sans">
+        <GoogleAnalytics GA_MEASUREMENT_ID="G-Y7K0K222D9" />
         <WebVitals />
         {children}
         <Suspense fallback={null}>


### PR DESCRIPTION
- Integrated Google Analytics across the application via the main layout.
- Implemented a consent verification check to ensure tracking only occurs after user approval.

[v0 Session](https://v0.app/chat/jmZwTGbSlIW)