### PR TITLE
Use professional contact email sitewide

### DIFF
--- a/app/[lang]/antiparoxes-kerkira/page.tsx
+++ b/app/[lang]/antiparoxes-kerkira/page.tsx
@@ -64,7 +64,7 @@ export default async function AntiparoxesKerkiraPage({ params }: { params: Promi
       "@type": "LocalBusiness",
       "name": "Faiacon - Τεχνική Κατασκευαστική",
       "telephone": "+30 698 779 7679",
-      "email": "faiacon@yahoo.com",
+      "email": "info@faiacon.gr",
       "address": {
         "@type": "PostalAddress",
         "addressLocality": "Κέρκυρα",

--- a/app/actions/send-email.ts
+++ b/app/actions/send-email.ts
@@ -57,7 +57,7 @@ export async function sendEmail(formData: FormData) {
     const resend = new Resend(process.env.RESEND_API_KEY)
     const { data, error } = await resend.emails.send({
       from: "Faiacon Website <onboarding@resend.dev>",
-      to: ["faiacon@yahoo.com"],
+      to: ["info@faiacon.gr"],
       replyTo: email,
       subject: `Νέα Φόρμα Επικοινωνίας από ${name || email}`,
       text: `

--- a/app/api/antiparoxes-lead/route.ts
+++ b/app/api/antiparoxes-lead/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 
-const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'faiacon@yahoo.com'
+const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'info@faiacon.gr'
 const LEADS_FROM_EMAIL = process.env.LEADS_FROM_EMAIL || 'onboarding@resend.dev'
 
 export async function POST(req: NextRequest) {

--- a/app/api/calculator-lead/route.ts
+++ b/app/api/calculator-lead/route.ts
@@ -4,7 +4,7 @@ import type { QuoteBreakdown, RenovationBreakdown, WindowsBreakdown } from '@/li
 import { fmtEur, fmtNum, QUALITY_LABELS_EL, MATERIAL_LABELS_EL, POOL_TYPE_LABELS_EL } from '@/lib/calculator/pricing'
 
 // Email configuration from environment variables with fallbacks
-const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'faiacon@yahoo.com'
+const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'info@faiacon.gr'
 const LEADS_FROM_EMAIL = process.env.LEADS_FROM_EMAIL || 'onboarding@resend.dev'
 
 // Dynamic import for Resend to avoid build-time initialization

--- a/app/api/career-application/route.ts
+++ b/app/api/career-application/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest) {
     const cvFileName = sanitize(body.cvFileName)
     const comments = sanitize(body.comments)
 
-    const hrEmail = process.env.HR_RECEIVER_EMAIL || "faiacon@yahoo.com"
+    const hrEmail = process.env.HR_RECEIVER_EMAIL || "info@faiacon.gr"
 
     const hrHtml = `
       <div style="font-family: Arial, sans-serif; max-width: 700px; margin: 0 auto; color: #222;">

--- a/app/components/antiparoxes-page.tsx
+++ b/app/components/antiparoxes-page.tsx
@@ -647,9 +647,9 @@ export default function AntiparoxesPage({ lang }: { lang: string }) {
                         <Phone className="w-5 h-5" />
                         <span>+30 698 779 7679</span>
                       </a>
-                      <a href="mailto:faiacon@yahoo.com" className="flex items-center gap-3 text-white hover:text-white/80 transition-colors">
+                      <a href="mailto:info@faiacon.gr" className="flex items-center gap-3 text-white hover:text-white/80 transition-colors">
                         <Mail className="w-5 h-5" />
-                        <span>faiacon@yahoo.com</span>
+                        <span>info@faiacon.gr</span>
                       </a>
                     </div>
                     <div className="mt-6">

--- a/app/components/appointment-page.tsx
+++ b/app/components/appointment-page.tsx
@@ -67,7 +67,7 @@ export default function AppointmentPage({ lang }: { lang: string }) {
                     <div>
                       <h3 className="font-semibold text-gray-900">{isEnglish ? "Email" : "Email"}</h3>
                       <Button variant="link" className="p-0 h-auto text-primary" asChild>
-                        <Link href="mailto:faiacon@yahoo.com">faiacon@yahoo.com</Link>
+                        <Link href="mailto:info@faiacon.gr">info@faiacon.gr</Link>
                       </Button>
                     </div>
                   </div>
@@ -161,7 +161,7 @@ export default function AppointmentPage({ lang }: { lang: string }) {
                 </Button>
 
                 <Button className="w-full border border-primary text-primary hover:bg-primary/5 text-base font-semibold py-6" asChild>
-                  <Link href="mailto:faiacon@yahoo.com">
+                  <Link href="mailto:info@faiacon.gr">
                     {isEnglish ? "Send Email" : "Στείλτε Email"}
                   </Link>
                 </Button>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -23,7 +23,7 @@ export function Footer() {
                 </div>
                 <div className="flex items-center space-x-3">
                   <Mail className="h-5 w-5" />
-                  <span>faiacon@yahoo.com</span>
+                  <span>info@faiacon.gr</span>
                 </div>
                 <div className="flex items-start space-x-3">
                   <MapPin className="h-5 w-5 mt-1" />

--- a/app/components/structured-data.tsx
+++ b/app/components/structured-data.tsx
@@ -13,7 +13,7 @@ export function LocalBusinessSchema() {
     logo: `${SITE_URL}/logo-faiacon.png`,
     image: `${SITE_URL}/images/petrinI-vila-kerkira.jpg`,
     telephone: "+30-6987797679",
-    email: "faiacon@yahoo.com",
+    email: "info@faiacon.gr",
     foundingDate: "1990",
     priceRange: "€€€",
     currenciesAccepted: "EUR",


### PR DESCRIPTION
Replaces the public Yahoo address with info@faiacon.gr across contact sections, mailto links, structured data, and default lead recipients. Validation: no application-source references to faiacon@yahoo.com remain. Local build/type checks are blocked by pre-existing project errors unrelated to this email-only change.