### PR TITLE
Route form APIs to professional email

### DIFF
--- a/app/actions/send-email.ts
+++ b/app/actions/send-email.ts
@@ -2,6 +2,8 @@
 
 import { Resend } from "resend"
 
+const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || "info@faiacon.gr"
+
 // Escape user input before interpolating into email HTML
 function escapeHtml(input: unknown): string {
   return String(input ?? "")
@@ -57,7 +59,7 @@ export async function sendEmail(formData: FormData) {
     const resend = new Resend(process.env.RESEND_API_KEY)
     const { data, error } = await resend.emails.send({
       from: "Faiacon Website <onboarding@resend.dev>",
-      to: ["faiacon@yahoo.com"],
+      to: [LEADS_TO_EMAIL],
       replyTo: email,
       subject: `Νέα Φόρμα Επικοινωνίας από ${name || email}`,
       text: `

--- a/app/api/antiparoxes-lead/route.ts
+++ b/app/api/antiparoxes-lead/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 
-const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'faiacon@yahoo.com'
+const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'info@faiacon.gr'
 const LEADS_FROM_EMAIL = process.env.LEADS_FROM_EMAIL || 'onboarding@resend.dev'
 
 export async function POST(req: NextRequest) {
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
     const { data, error } = await resend.emails.send({
       from: LEADS_FROM_EMAIL,
       to: [LEADS_TO_EMAIL],
-      reply_to: email,
+      replyTo: email,
       subject: `Νέα Αίτηση Αντιπαροχής από ${name}`,
       html: `
         <div style="font-family: Arial, sans-serif; max-width: 600px;">

--- a/app/api/calculator-lead/route.ts
+++ b/app/api/calculator-lead/route.ts
@@ -4,7 +4,7 @@ import type { QuoteBreakdown, RenovationBreakdown, WindowsBreakdown } from '@/li
 import { fmtEur, fmtNum, QUALITY_LABELS_EL, MATERIAL_LABELS_EL, POOL_TYPE_LABELS_EL } from '@/lib/calculator/pricing'
 
 // Email configuration from environment variables with fallbacks
-const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'faiacon@yahoo.com'
+const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || 'info@faiacon.gr'
 const LEADS_FROM_EMAIL = process.env.LEADS_FROM_EMAIL || 'onboarding@resend.dev'
 
 // Dynamic import for Resend to avoid build-time initialization

--- a/app/api/career-application/route.ts
+++ b/app/api/career-application/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest) {
     const cvFileName = sanitize(body.cvFileName)
     const comments = sanitize(body.comments)
 
-    const hrEmail = process.env.HR_RECEIVER_EMAIL || "faiacon@yahoo.com"
+    const hrEmail = process.env.HR_RECEIVER_EMAIL || "info@faiacon.gr"
 
     const hrHtml = `
       <div style="font-family: Arial, sans-serif; max-width: 700px; margin: 0 auto; color: #222;">
@@ -140,7 +140,7 @@ export async function POST(req: NextRequest) {
     const { error: hrError } = await resend.emails.send({
       from: "ΦαιάCon Careers <onboarding@resend.dev>",
       to: [hrEmail],
-      reply_to: email,
+      replyTo: email,
       subject: `Νέα Αίτηση Εργασίας - ${name}`,
       html: hrHtml,
     })


### PR DESCRIPTION
Routes calculator, contact/appointment, property-exchange, and career notification APIs to the LEADS_TO_EMAIL and HR_RECEIVER_EMAIL Vercel settings. Also fixes the two Resend replyTo option names so those routes use the supported SDK field.