### PR TITLE
Unify transactional email sender

### DIFF
--- a/app/actions/send-email.ts
+++ b/app/actions/send-email.ts
@@ -3,6 +3,7 @@
 import { Resend } from "resend"
 
 const LEADS_TO_EMAIL = process.env.LEADS_TO_EMAIL || "info@faiacon.gr"
+const LEADS_FROM_EMAIL = process.env.LEADS_FROM_EMAIL || "onboarding@resend.dev"
 
 // Escape user input before interpolating into email HTML
 function escapeHtml(input: unknown): string {
@@ -58,7 +59,7 @@ export async function sendEmail(formData: FormData) {
 
     const resend = new Resend(process.env.RESEND_API_KEY)
     const { data, error } = await resend.emails.send({
-      from: "Faiacon Website <onboarding@resend.dev>",
+      from: `Faiacon Website <${LEADS_FROM_EMAIL}>`,
       to: [LEADS_TO_EMAIL],
       replyTo: email,
       subject: `Νέα Φόρμα Επικοινωνίας από ${name || email}`,

--- a/app/api/antiparoxes-lead/route.ts
+++ b/app/api/antiparoxes-lead/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
 
     // Send email via Resend
     const { data, error } = await resend.emails.send({
-      from: LEADS_FROM_EMAIL,
+      from: `Faiacon <${LEADS_FROM_EMAIL}>`,
       to: [LEADS_TO_EMAIL],
       replyTo: email,
       subject: `Νέα Αίτηση Αντιπαροχής από ${name}`,

--- a/app/api/calculator-lead/route.ts
+++ b/app/api/calculator-lead/route.ts
@@ -573,7 +573,7 @@ export async function POST(request: NextRequest) {
     }
 
     const { data, error } = await resend.emails.send({
-      from: LEADS_FROM_EMAIL,
+      from: `Faiacon <${LEADS_FROM_EMAIL}>`,
       to: LEADS_TO_EMAIL,
       subject: `[Faiacon] Νέα Αίτηση Προσφοράς — ${lead.contact.name}`,
       html: generateEmailHTML(lead, breakdown),

--- a/app/api/career-application/route.ts
+++ b/app/api/career-application/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { Resend } from "resend"
 
+const LEADS_FROM_EMAIL = process.env.LEADS_FROM_EMAIL || "onboarding@resend.dev"
+
 function sanitize(val: unknown): string {
   if (typeof val !== "string") return ""
   return val.replace(/[<>]/g, "").trim().slice(0, 2000)
@@ -138,7 +140,7 @@ export async function POST(req: NextRequest) {
     // Send to HR
     const resend = new Resend(process.env.RESEND_API_KEY)
     const { error: hrError } = await resend.emails.send({
-      from: "ΦαιάCon Careers <onboarding@resend.dev>",
+      from: `ΦαιάCon Careers <${LEADS_FROM_EMAIL}>`,
       to: [hrEmail],
       replyTo: email,
       subject: `Νέα Αίτηση Εργασίας - ${name}`,
@@ -152,7 +154,7 @@ export async function POST(req: NextRequest) {
 
     // Send confirmation to applicant
     await resend.emails.send({
-      from: "ΦαιάCon <onboarding@resend.dev>",
+      from: `ΦαιάCon <${LEADS_FROM_EMAIL}>`,
       to: [email],
       subject: "Λάβαμε την αίτησή σας - ΦαιάCon",
       html: confirmHtml,


### PR DESCRIPTION
## Τι αλλάζει
Ενοποιεί τον sender των τεσσάρων ροών email: calculator, αντιπαροχή, αιτήσεις εργασίας και φόρμα επικοινωνίας.

## Γιατί
Μετά την επιβεβαίωση του `faiacon.gr` στο Resend, όλες οι ροές θα στέλνουν από τον ίδιο επαγγελματικό sender αντί για το δοκιμαστικό `onboarding@resend.dev`.

## Έλεγχοι
- `git diff --check` επιτυχές.
- `npx tsc --noEmit`: αποτυγχάνει μόνο από πέντε ήδη υπάρχοντα άσχετα σφάλματα σε analytics, BusinessCard και calculator.